### PR TITLE
Fix deserialization of root key id

### DIFF
--- a/src/main/java/org/biscuitsec/biscuit/token/Biscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Biscuit.java
@@ -104,18 +104,13 @@ public class Biscuit extends UnverifiedBiscuit {
             List<byte[]> revocation_ids = s.revocation_identifiers();
 
             Option<SerializedBiscuit> c = Option.some(s);
-            return new Biscuit(authority, blocks, authority.symbols, s, revocation_ids, root_key_id);
+            return new Biscuit(authority, blocks, authority.symbols, s, revocation_ids);
         }
     }
 
     Biscuit(Block authority, List<Block> blocks, SymbolTable symbols, SerializedBiscuit serializedBiscuit,
             List<byte[]> revocation_ids) {
         super(authority, blocks, symbols, serializedBiscuit,  revocation_ids);
-    }
-
-    Biscuit(Block authority, List<Block> blocks, SymbolTable symbols, SerializedBiscuit serializedBiscuit,
-            List<byte[]> revocation_ids, Option<Integer> root_key_id) {
-        super(authority, blocks, symbols, serializedBiscuit, revocation_ids, root_key_id);
     }
 
     /**

--- a/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
@@ -29,7 +29,6 @@ public class UnverifiedBiscuit {
     final SymbolTable symbols;
     final SerializedBiscuit serializedBiscuit;
     final List<byte[]> revocation_ids;
-    final Option<Integer> root_key_id;
 
     UnverifiedBiscuit(Block authority, List<Block> blocks, SymbolTable symbols, SerializedBiscuit serializedBiscuit,
                        List<byte[]> revocation_ids) {
@@ -38,18 +37,6 @@ public class UnverifiedBiscuit {
         this.symbols = symbols;
         this.serializedBiscuit = serializedBiscuit;
         this.revocation_ids = revocation_ids;
-        this.root_key_id = Option.none();
-    }
-
-    UnverifiedBiscuit(Block authority, List<Block> blocks, SymbolTable symbols, SerializedBiscuit serializedBiscuit,
-                      List<byte[]> revocation_ids,
-                      Option<Integer> root_key_id) {
-        this.authority = authority;
-        this.blocks = blocks;
-        this.symbols = symbols;
-        this.serializedBiscuit = serializedBiscuit;
-        this.revocation_ids = revocation_ids;
-        this.root_key_id = root_key_id;
     }
 
     /**
@@ -224,7 +211,7 @@ public class UnverifiedBiscuit {
     }
 
     public Option<Integer> root_key_id() {
-        return this.root_key_id;
+        return this.serializedBiscuit.root_key_id;
     }
 
     /**
@@ -347,7 +334,7 @@ public class UnverifiedBiscuit {
     public Biscuit verify(KeyDelegate delegate) throws Error, NoSuchAlgorithmException, SignatureException, InvalidKeyException {
         SerializedBiscuit serializedBiscuit = this.serializedBiscuit;
 
-        Option<PublicKey> root = delegate.root_key(root_key_id);
+        Option<PublicKey> root = delegate.root_key(serializedBiscuit.root_key_id);
         if(root.isEmpty()) {
             throw new InvalidKeyException("unknown root key id");
         }

--- a/src/main/java/org/biscuitsec/biscuit/token/format/SerializedBiscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/format/SerializedBiscuit.java
@@ -161,7 +161,9 @@ public class SerializedBiscuit {
         }
         Proof proof = new Proof(secretKey, signature);
 
-        return new SerializedBiscuit(authority, blocks, proof);
+        Option<Integer> rootKeyId = data.hasRootKeyId() ? Option.some(data.getRootKeyId()) : Option.none();
+
+        return new SerializedBiscuit(authority, blocks, proof, rootKeyId);
     }
 
 


### PR DESCRIPTION
- Fix missing root key id in construction of `SerializedBiscuit`.
- Use root key id directly from `SerializedBiscuit` to avoid losing it when copying objects.